### PR TITLE
Fixed inconsistencies between Host and Service notifications

### DIFF
--- a/src/slack-notifications/slack-notifications-command.conf
+++ b/src/slack-notifications/slack-notifications-command.conf
@@ -105,9 +105,9 @@ object NotificationCommand "slack-notifications-command" {
             service_state_text = " is still in state " + service_state
         }
 
-        mainTitle = ":" + icon + ": " + service_state + ": Service " + service_name_with_link + service_state_text
+        mainTitle = ":" + icon + ": " + notification_type + ": Service " + service_name_with_link + service_state_text
         output = short_service_output
-        fallback = service_state + notification_type_custom_text + ": Service " + service_name + service_state_text + " on host " + host_name + ". Plugin output: " + short_service_output
+        fallback = notification_type + notification_type_custom_text + ": Service " + service_name + service_state_text + " on host " + host_name + ". Plugin output: ```" + short_service_output + "```"
     } else {
         try {
           var color = slack_color_dictionary.get(host_state)


### PR DESCRIPTION
Since the notification message rewrite, the service notification text does not include the notification type anymore.
Also updated service `fallback` to be similar as on a host.